### PR TITLE
Update PhpSpreadsheetDriver.php

### DIFF
--- a/src/Drivers/PhpSpreadsheetDriver.php
+++ b/src/Drivers/PhpSpreadsheetDriver.php
@@ -89,6 +89,8 @@ class PhpSpreadsheetDriver implements SheetsInterface, GridInterface, MixInterfa
         }
 
         $writer->save($file);
+        
+        $this->spreadsheet->disconnectWorksheets();
     }
 
     /**


### PR DESCRIPTION
@AnourValar when you use many template (foreach) Memory increase out of memory
example template1, template 2, template3...
when finished export template1 and don't use template1 and then load template2
Memory don't release template1.
So, I edit disconnect worksheet to release memory
Result, Memory don't increase if you foreach load template.

![image](https://user-images.githubusercontent.com/110110247/208364652-6c5c61e3-5b72-4925-9bf3-d806f7dbad58.png)

![image](https://user-images.githubusercontent.com/110110247/208364708-f6d2ffea-bc3f-4f1f-8637-6b5751491482.png)

You can see different between two source code 

You can see library PhpSpreadsheet clear memory after load template here
https://github.com/PHPOffice/PhpSpreadsheet/compare/master...oleibman:PhpSpreadsheet:namespace6#diff-a482c64db4b5ce7ae0cec2855477df7db4d65a71d391cd64531d01e00ef28dc5R41
