### PR TITLE
Resolve PHP 8.4 deprecation warnings

### DIFF
--- a/src/Generated.php
+++ b/src/Generated.php
@@ -48,10 +48,10 @@ class Generated
      * Save generated document to the file
      *
      * @param string $filename
-     * @param \AnourValar\Office\Format $format
+     * @param \AnourValar\Office\Format|null $format
      * @return int|null
      */
-    public function saveAs(string $filename, Format $format = null): ?int
+    public function saveAs(string $filename, ?Format $format = null): ?int
     {
         if (! $format) {
             $format = Format::from(mb_strtolower(pathinfo($filename, PATHINFO_EXTENSION)));
@@ -63,7 +63,7 @@ class Generated
     /**
      * Set hookSave
      *
-     * @param ?\Closure $closure
+     * @param \Closure|null $closure
      * @return self
      */
     public function hookSave(?\Closure $closure): self


### PR DESCRIPTION
Resolved the deprecation warnings that would occur when upgrading to PHP 8.4.

PHP 8.4 was already implicitly supported by the composer version constraints. Even though I couldn't install the dev dependencies because `vimeo/psalm` does not support 8.4 yet.

Instead, I've installed dependencies with PHP 8.3, and upgraded my php version afterwards.

**Test results before change:**
---
<img width="655" alt="image" src="https://github.com/user-attachments/assets/1da69851-02e5-4bc4-9663-a894c25d9cb6">

**Test results after change:**
---
<img width="655" alt="image" src="https://github.com/user-attachments/assets/edf2a2d5-fb67-4009-9cdd-964d7ff31ba6">


