### PR TITLE
Apply sensible defaults for git config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.phpunit.cache/
+vendor/
+composer.lock
+.php-cs-fixer.cache


### PR DESCRIPTION
While working on https://github.com/AnourValar/office/pull/30 I found out there were no `.gitignore` and `.gitattributes` files in the repo. I've added them with some sensible values in it to keep working on the repository easy and keeping the releases clean.